### PR TITLE
Camera Controls

### DIFF
--- a/Engine/Camera.h
+++ b/Engine/Camera.h
@@ -1,0 +1,148 @@
+/**
+    @class Camera Camera.h "Engine/Camera.h"
+    @brief Class for handling camera transformations
+    @details This class handles camera transformations such as movements and rotations
+    @author Kyler Legault
+    @date 11/4/24
+*/
+
+#pragma once
+
+#ifndef CAMERA_H
+#define CAMERA_H
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include "MatrixStack.h"
+
+class Camera
+{
+  MatrixStack *ms;
+  glm::vec3 cameraPos, cameraUp, cameraFront, cameraDirection, cameraRight, up;
+  float pitch, yaw, roll;
+
+  void updateCamera();
+
+public:
+  Camera(MatrixStack *_ms, glm::vec3 _up);
+  void SlideFront(float speed);
+  void SlideSide(float speed);
+  void SlideUp(float speed);
+  void Pitch(float angle);
+  void Yaw(float angle);
+  void Roll(float angle);
+};
+
+/**
+    @brief Creates the Camera class and initializes vectors
+    @details Creates the Camera class and derives the up, right, and front vectors
+    @param ms Matrix Stack used for transformations
+    @param up World up vector
+*/
+Camera::Camera(MatrixStack *_ms, glm::vec3 _up = glm::vec3(0, 1, 0))
+{
+  // TODO: Maybe add start position as a parameter?
+  ms = _ms;
+  up = _up;
+
+  // Only used in setup
+  glm::vec3 cameraTarget = glm::vec3(0, 0, 0);
+
+  // Will vary with movement
+  cameraPos = glm::vec3(0, 0, 3);
+  cameraDirection = glm::normalize(cameraPos - cameraTarget);
+  cameraFront = glm::normalize(cameraPos - cameraDirection);
+  cameraRight = glm::normalize(glm::cross(up, cameraDirection));
+  cameraUp = glm::normalize(glm::cross(cameraDirection, cameraRight));
+
+  updateCamera();
+}
+
+/**
+    @brief Moves camera front and back
+    @details Adds cameraFront * speed to cameraPos
+    @param speed Amount to move by
+*/
+void Camera::SlideFront(float speed)
+{
+  cameraPos += speed * cameraFront;
+  updateCamera();
+}
+
+/**
+    @brief Moves camera side to side
+    @details Adds cameraRight * speed to cameraPos
+    @param speed Amount to move by
+*/
+void Camera::SlideSide(float speed)
+{
+  cameraPos += speed * cameraRight;
+  updateCamera();
+}
+
+/**
+    @brief Moves camera up and down
+    @details Adds up * speed to cameraPos
+    @param speed Amount to move by
+*/
+void Camera::SlideUp(float speed)
+{
+  cameraPos += speed * up;
+  updateCamera();
+}
+
+/**
+    @brief Adjusts camera pitch (up and down rotation)
+    @details Adds angle to pitch
+    @param angle Angle to move by
+*/
+void Camera::Pitch(float angle)
+{
+  pitch += angle;
+  if (pitch > 89.0f)
+    pitch = 89.0f;
+  if (pitch < -89.0f)
+    pitch = -89.0f;
+
+  updateCamera();
+}
+
+/**
+    @brief Adjusts camera pitch (side to side rotation)
+    @details Adds angle to yaw
+    @param angle Angle to move by
+*/
+void Camera::Yaw(float angle)
+{
+  yaw += angle;
+  updateCamera();
+}
+
+// TODO: implement this
+void Camera::Roll(float angle)
+{
+  // updateCamera();
+}
+
+/**
+    @brief Updates camera variables
+    @details Recalculates camera directional vector/axes vectors and produces a view matrix on the matrix stack
+*/
+void Camera::updateCamera()
+{
+  // Calculate new camera direction
+  cameraDirection.x = cos(glm::radians(yaw)) * cos(glm::radians(pitch));
+  cameraDirection.y = sin(glm::radians(pitch));
+  cameraDirection.z = sin(glm::radians(yaw)) * cos(glm::radians(pitch));
+
+  // Recalculate camera variables
+  cameraRight = glm::normalize(glm::cross(up, cameraDirection));
+  cameraUp = glm::normalize(glm::cross(cameraDirection, cameraRight));
+  cameraFront = glm::normalize(cameraDirection);
+
+  // TODO: Implement roll calculation for cameraUp
+
+  // Derives view matrix
+  ms->top() = glm::lookAt(cameraPos, cameraPos + cameraFront, cameraUp);
+}
+
+#endif

--- a/Engine/MatrixStack.h
+++ b/Engine/MatrixStack.h
@@ -8,10 +8,25 @@
 
 class MatrixStack
 {
-public:
+  static MatrixStack *instancePtr;
+  std::stack<glm::mat4> stack;
+
   MatrixStack()
   {
     stack.push(glm::mat4(1.0f)); // Initialize with identity matrix
+  }
+
+public:
+  MatrixStack(MatrixStack &) = delete;
+  void operator=(const MatrixStack &) = delete;
+
+  static MatrixStack *getInstance()
+  {
+    if (instancePtr == nullptr)
+    {
+      instancePtr = new MatrixStack();
+    }
+    return instancePtr;
   }
 
   void push()
@@ -28,9 +43,8 @@ public:
   {
     return stack.top();
   }
-
-private:
-  std::stack<glm::mat4> stack;
 };
+
+MatrixStack *MatrixStack::instancePtr = nullptr;
 
 #endif

--- a/Engine/MatrixStack.h
+++ b/Engine/MatrixStack.h
@@ -1,0 +1,36 @@
+#pragma once
+#ifndef MATRIXSTACK_H
+#define MATRIXSTACK_H
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <stack>
+
+class MatrixStack
+{
+public:
+  MatrixStack()
+  {
+    stack.push(glm::mat4(1.0f)); // Initialize with identity matrix
+  }
+
+  void push()
+  {
+    stack.push(stack.top()); // Duplicate the top matrix
+  }
+
+  void pop()
+  {
+    stack.pop();
+  }
+
+  glm::mat4 &top()
+  {
+    return stack.top();
+  }
+
+private:
+  std::stack<glm::mat4> stack;
+};
+
+#endif

--- a/Engine/Shape.h
+++ b/Engine/Shape.h
@@ -35,6 +35,7 @@ private:
     int drawFirst, drawElements; // Specifies how to draw data
     glm::mat4 model, view;       // Transformation matrices
     float rotation;
+    MatrixStack *ms;
 
 public:
     Shape(GLenum type, float *vertices, int vSize);                                   // Creates just a VAO and VBO
@@ -46,7 +47,7 @@ public:
     void Bind();                                                                      // Binds all of the objects
     void Unbind();                                                                    // Unbinds all of the objects
     void SetDrawData(int first, int elements);                                        // Sets the Draw data
-    void Draw(MatrixStack *ms);                                                       // Draws the data
+    void Draw();                                                                      // Draws the data
     void SetTexture(Texture &txtr);                                                   // Sets texture to an already existing one
     void SetShader(Shader &shdr);
     void Rotate(float angle, glm::vec3 axis);
@@ -167,6 +168,8 @@ void Shape::initMatrices()
 {
     model = glm::mat4(1.0f);
     view = glm::mat4(1.0f);
+
+    ms = MatrixStack::getInstance();
 }
 
 /**
@@ -247,7 +250,7 @@ void Shape::SetDrawData(int first, int elements)
     @brief Draws the shape
     @details Uses the provided shader, binds the object, calls its draw function, and unbinds.
  */
-void Shape::Draw(MatrixStack *ms)
+void Shape::Draw()
 {
     ms->push();
     ms->top() *= view * model;

--- a/Engine/Shape.h
+++ b/Engine/Shape.h
@@ -17,6 +17,7 @@
 #include "VB.h"
 #include "Texture.h"
 #include "Shader.h"
+#include "MatrixStack.h"
 class Shape
 {
 private:
@@ -45,7 +46,7 @@ public:
     void Bind();                                                                      // Binds all of the objects
     void Unbind();                                                                    // Unbinds all of the objects
     void SetDrawData(int first, int elements);                                        // Sets the Draw data
-    void Draw();                                                                      // Draws the data
+    void Draw(MatrixStack *ms);                                                       // Draws the data
     void SetTexture(Texture &txtr);                                                   // Sets texture to an already existing one
     void SetShader(Shader &shdr);
     void Rotate(float angle, glm::vec3 axis);
@@ -246,11 +247,12 @@ void Shape::SetDrawData(int first, int elements)
     @brief Draws the shape
     @details Uses the provided shader, binds the object, calls its draw function, and unbinds.
  */
-void Shape::Draw()
+void Shape::Draw(MatrixStack *ms)
 {
+    ms->push();
+    ms->top() *= view * model;
     shader.use();
-    shader.setMatrix4("model", model);
-    shader.setMatrix4("view", view);
+    shader.setMatrix4("viewmodel", ms->top());
     Bind();
     switch (drawMethod)
     {
@@ -263,6 +265,7 @@ void Shape::Draw()
         break;
     }
     Unbind();
+    ms->pop();
 }
 
 /**

--- a/Resources/Shaders/Simple.vs
+++ b/Resources/Shaders/Simple.vs
@@ -3,12 +3,11 @@ layout (location = 0) in vec3 aPos;
 
 out vec3 myColor;
 
-uniform mat4 model;
-uniform mat4 view;
+uniform mat4 viewmodel;
 uniform mat4 projection;
 
 void main()
 {
-    gl_Position = projection * view * model * vec4(aPos, 1.0);
+    gl_Position = projection * viewmodel * vec4(aPos, 1.0);
     myColor = vec3(aPos.x + .5f, aPos.y + .5f, aPos.z + .5f);
 }

--- a/main.cpp
+++ b/main.cpp
@@ -13,17 +13,25 @@
 #include "Engine/Shader.h"
 #include "Engine/Shape.h"
 #include "Engine/Texture.h"
+#include "Engine/MatrixStack.h"
+#include "Engine/Camera.h"
 //====| Namespaces |====//
 using namespace std;
 
 //====| Global Variables |====//
 int _width = 800, _height = 600;
+float lastX = 400, lastY = 300; // Mouse variables
+bool isFirstMouse = true;
 Shape *currentShape;
+MatrixStack *ms;
+Camera *camera;
 //====| Function Declarations |====//
 GLFWwindow *initWindow();                                                  // Create and initialize window to default variables
 bool initGlad();                                                           // Initialize glad to expose OpenGL function pointers
 void framebuffer_size_callback(GLFWwindow *window, int width, int height); // function that sets GLFWwindow size when user changes it
+void mouse_callback(GLFWwindow *window, double xpos, double ypos);         // Mouse input callback
 void processInput(GLFWwindow *window);                                     // Process user input
+
 //====| Main |====//
 int main(int, char **)
 {
@@ -35,6 +43,9 @@ int main(int, char **)
 
     Shader shader1("../Resources/Shaders/Simple.vs", "../Resources/Shaders/Simple.fs");
     Shader shader2("../Resources/Shaders/4.1.texture.vs", "../Resources/Shaders/4.1.texture.fs");
+
+    ms = new MatrixStack();
+    camera = new Camera(ms);
 
     // VAO textureVAO = bindImageToVAO();
     // Vertices coordinates
@@ -105,7 +116,15 @@ int main(int, char **)
     shape1.SetShader(shader1);
 
     // Move the shape into the view volume for viewing
-    shape1.Translate(glm::vec3(0, 0, -5.0f));
+    shape1.Translate(glm::vec3(0, 0, 5.0f));
+
+    Shape shape2 = Shape(GL_STATIC_DRAW, "../Resources/Models/cube.obj");
+    shape2.SetVertexPointer(0, 3, 3, 0);
+    shape2.SetDrawData(0, 12 * 3);
+    shape2.SetShader(shader1);
+
+    // Move the shape into the view volume for viewing
+    shape2.Translate(glm::vec3(0, 5.0f, 5.0f));
 
     currentShape = &shape1;
 
@@ -122,7 +141,8 @@ int main(int, char **)
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
         // texShape.Draw();
-        shape1.Draw();
+        shape1.Draw(ms);
+        shape2.Draw(ms);
 
         glfwSwapBuffers(window);
         glfwPollEvents();
@@ -160,6 +180,8 @@ GLFWwindow *initWindow()
 
     glfwGetWindowSize(window, &_width, &_height);
     glfwSetFramebufferSizeCallback(window, framebuffer_size_callback); // Call back so user can resize the window
+    glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);       // Fix the cursor to the middle of the window
+    glfwSetCursorPosCallback(window, mouse_callback);
 
     if (!initGlad()) // If failed, exit
     {
@@ -208,6 +230,30 @@ void framebuffer_size_callback(GLFWwindow *window, int width, int height)
     glViewport(0, 0, _width, _height);
 }
 
+void mouse_callback(GLFWwindow *window, double xpos, double ypos)
+{
+    if (isFirstMouse) // initially set to true
+    {
+        lastX = xpos;
+        lastY = ypos;
+        isFirstMouse = false;
+    }
+    float xoffset = xpos - lastX;
+    float yoffset = lastY - ypos; // reversed since y-coordinates range from bottom to top
+    lastX = xpos;
+    lastY = ypos;
+
+    const float sensitivity = 0.1f;
+    xoffset *= sensitivity;
+    yoffset *= sensitivity;
+
+    if (camera != nullptr)
+    {
+        camera->Pitch(yoffset);
+        camera->Yaw(xoffset);
+    }
+}
+
 /*
     Gets user input and responds accordingly
     Parameters: GLFWwindow* window
@@ -219,7 +265,7 @@ void processInput(GLFWwindow *window)
     {
         glfwSetWindowShouldClose(window, true);
     }
-    if (glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS)
+    if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS)
     {
         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
     }
@@ -229,34 +275,54 @@ void processInput(GLFWwindow *window)
     }
 
     // Shape controls
-    if (currentShape == nullptr)
+    if (currentShape != nullptr)
     {
-        return;
+
+        // Translation
+        if (glfwGetKey(window, GLFW_KEY_LEFT) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) != GLFW_PRESS)
+            currentShape->Translate(glm::vec3(-.025, 0, 0));
+        if (glfwGetKey(window, GLFW_KEY_RIGHT) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) != GLFW_PRESS)
+            currentShape->Translate(glm::vec3(.025, 0, 0));
+        if (glfwGetKey(window, GLFW_KEY_DOWN) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) != GLFW_PRESS)
+            currentShape->Translate(glm::vec3(0, -.025, 0));
+        if (glfwGetKey(window, GLFW_KEY_UP) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) != GLFW_PRESS)
+            currentShape->Translate(glm::vec3(0, .025, 0));
+
+        // Rotation
+        if (glfwGetKey(window, GLFW_KEY_LEFT) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS)
+            currentShape->Rotate(-.025, glm::vec3(0, 1, 0));
+        if (glfwGetKey(window, GLFW_KEY_RIGHT) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS)
+            currentShape->Rotate(.025, glm::vec3(0, 1, 0));
+        if (glfwGetKey(window, GLFW_KEY_DOWN) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS)
+            currentShape->Rotate(.025, glm::vec3(1, 0, 0));
+        if (glfwGetKey(window, GLFW_KEY_UP) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS)
+            currentShape->Rotate(-.025, glm::vec3(1, 0, 0));
+
+        // Scaling
+        if (glfwGetKey(window, GLFW_KEY_PERIOD) == GLFW_PRESS)
+            currentShape->Scale(1.01);
+        if (glfwGetKey(window, GLFW_KEY_COMMA) == GLFW_PRESS)
+            currentShape->Scale(0.99);
     }
 
-    // Translation
-    if (glfwGetKey(window, GLFW_KEY_LEFT) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) != GLFW_PRESS)
-        currentShape->Translate(glm::vec3(-.025, 0, 0));
-    if (glfwGetKey(window, GLFW_KEY_RIGHT) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) != GLFW_PRESS)
-        currentShape->Translate(glm::vec3(.025, 0, 0));
-    if (glfwGetKey(window, GLFW_KEY_DOWN) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) != GLFW_PRESS)
-        currentShape->Translate(glm::vec3(0, -.025, 0));
-    if (glfwGetKey(window, GLFW_KEY_UP) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) != GLFW_PRESS)
-        currentShape->Translate(glm::vec3(0, .025, 0));
-
-    // Rotation
-    if (glfwGetKey(window, GLFW_KEY_LEFT) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS)
-        currentShape->Rotate(-.025, glm::vec3(0, 1, 0));
-    if (glfwGetKey(window, GLFW_KEY_RIGHT) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS)
-        currentShape->Rotate(.025, glm::vec3(0, 1, 0));
-    if (glfwGetKey(window, GLFW_KEY_DOWN) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS)
-        currentShape->Rotate(.025, glm::vec3(1, 0, 0));
-    if (glfwGetKey(window, GLFW_KEY_UP) == GLFW_PRESS && glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS)
-        currentShape->Rotate(-.025, glm::vec3(1, 0, 0));
-
-    // Scaling
-    if (glfwGetKey(window, GLFW_KEY_PERIOD) == GLFW_PRESS)
-        currentShape->Scale(1.01);
-    if (glfwGetKey(window, GLFW_KEY_COMMA) == GLFW_PRESS)
-        currentShape->Scale(0.99);
+    if (camera != nullptr)
+    {
+        // Translation
+        if (glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS)
+            camera->SlideFront(0.05);
+        if (glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS)
+            camera->SlideFront(-.05);
+        if (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS)
+            camera->SlideSide(.05);
+        if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS)
+            camera->SlideSide(-.05);
+        if (glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_PRESS)
+            camera->SlideUp(.05);
+        if (glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS)
+            camera->SlideUp(-.025);
+        if (glfwGetKey(window, GLFW_KEY_Q) == GLFW_PRESS)
+            camera->Roll(.05);
+        if (glfwGetKey(window, GLFW_KEY_E) == GLFW_PRESS)
+            camera->Roll(-.025);
+    }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -44,7 +44,7 @@ int main(int, char **)
     Shader shader1("../Resources/Shaders/Simple.vs", "../Resources/Shaders/Simple.fs");
     Shader shader2("../Resources/Shaders/4.1.texture.vs", "../Resources/Shaders/4.1.texture.fs");
 
-    ms = new MatrixStack();
+    ms = MatrixStack::getInstance();
     camera = new Camera(ms);
 
     // VAO textureVAO = bindImageToVAO();
@@ -141,8 +141,8 @@ int main(int, char **)
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
         // texShape.Draw();
-        shape1.Draw(ms);
-        shape2.Draw(ms);
+        shape1.Draw();
+        shape2.Draw();
 
         glfwSwapBuffers(window);
         glfwPollEvents();


### PR DESCRIPTION
Implements the camera and controls. Roll is not implemented still, but there are normal controls. 

Since the camera produces a view matrix, I added a matrix stack class. This way, the camera will set the first matrix in the stack. Then shapes can add a copy of that matrix to the top of the stack, apply transformations, and then pop it back off. This can also be useful if we want to do other transformations and then undo them.

I also combined the view and model matrix in the shader, instead opting to multiply them on the cpu. This saves having to perform the multiplication for every vertex which could get costly.